### PR TITLE
Fix bug in resolveDomain function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,8 @@ function hash(secret, text) {
 
 function resolveDomain(req) {
     var host = req.get('host'); // Ex: "mysite.com:8000"
-    var domain = host.substr(0, host.indexOf(':') || host.length); // Ex: "mysite.com"
+    var truncateAt = host.indexOf(':');
+    var domain = host.substr(0, truncateAt > -1 ? truncateAt : host.length); // Ex: "mysite.com"
 
     return '.' + domain;
 }
@@ -552,64 +553,64 @@ module.exports = {
         }
 
         return function (req, res, next) {
-                        
+
             // An array to show us the matching excluded urls. If this array
             // contains any values, we should skip out and allow.
             var urlToTest;
             var excludeTheseUrls;
-            
+
             // Set JWT in header and cookie before response goes out
-            // This is done in onHeaders since we need to wait for any service 
-            // calls (e.g. auth) which may otherwise change the state of 
+            // This is done in onHeaders since we need to wait for any service
+            // calls (e.g. auth) which may otherwise change the state of
             // our token
             onHeaders(res, function () {
                 drop(req, res, options);
             });
-            
+
             // Skip out on non mutable REST methods
             if (/GET|HEAD|OPTIONS|TRACE/i.test(req.method)) {
                 return next();
             }
-            
+
             if (excludeUrls.length) {
-                                            
+
                 // We only want to verify certain requests
-                urlToTest = req.originalUrl;                
+                urlToTest = req.originalUrl;
                 excludeTheseUrls = excludeUrls.filter(function (excludeUrl) {
 
                     if (isArray(excludeUrl)) {
-                        
-                        var expression = excludeUrl[0];   
+
+                        var expression = excludeUrl[0];
                         var options = excludeUrl[1] || '';
-                        
+
                         return new RegExp(expression, options).test(urlToTest);
                     }
                     else if (isRegExp(excludeUrl)) {
-                        
+
                         return excludeUrl.test(urlToTest);
                     }
                     else if (isString(excludeUrl)) {
-                        
+
                         // Setup some variables: regExp for regExp testing and
                         // some bits to use in the indexOf comparison
-                        var regExp = new RegExp(excludeUrl);                        
+                        var regExp = new RegExp(excludeUrl);
                         var bits = ((urlToTest || '').split(/[?#]/, 1))[0];
 
-                        // Test regular expression strings first                        
+                        // Test regular expression strings first
                         if (regExp.exec(urlToTest)) {
                             return true;
                         }
-                        
+
                         // If we are still here, test the legacy indexOf case
                         return excludeUrls.indexOf(bits) !== -1;
                     }
                 });
-                
+
                 // If the filter above actually found anything, that means
                 // we matched on the possible exclusions. In this case, var's
-                // just pop out and var the next piece of middleware have a 
+                // just pop out and var the next piece of middleware have a
                 // shot.
-                if (excludeTheseUrls.length) {                    
+                if (excludeTheseUrls.length) {
                     return next();
                 }
             }
@@ -619,7 +620,7 @@ module.exports = {
             }
             catch (err) {
 
-                // If we get a CSRFError, we can send a 401 to trigger a retry, 
+                // If we get a CSRFError, we can send a 401 to trigger a retry,
                 // otherwise the error will be unhandled
                 if (err instanceof CSRFError) {
                     res.status(401);

--- a/test/jwtCsrfSpec.js
+++ b/test/jwtCsrfSpec.js
@@ -115,7 +115,7 @@ function runMiddleware(req, res, options, callback) {
 }
 
 describe('middleware', function() {
-    
+
     it('should support RegExp excludeUrls in options', function() {
 
         var req = {method: 'POST', originalUrl:'/sOmEuRl/somepath/allowMe'};
@@ -137,7 +137,7 @@ describe('middleware', function() {
         runMiddleware(req, res, options, function(err) {
             should.exist(err);
         });
-        
+
         req.originalUrl = '/some/other/path/to/zomethingElse';
         runMiddleware(req, res, options, function(err) {
             should.not.exist(err);
@@ -160,7 +160,7 @@ describe('middleware', function() {
         runMiddleware(req, res, options, function(err) {
             should.exist(err);
         });
-        
+
         req.originalUrl = '/somePath/to/another/Place';
         runMiddleware(req, res, options, function(err) {
             should.not.exist(err);
@@ -172,7 +172,7 @@ describe('middleware', function() {
             should.not.exist(err);
             assert(res.headers[HEADER_NAME], 'Expected JWT header to be present');
         });
-        
+
         req.originalUrl = '/AnOtHeR/pAtH/to/yet/another/place';
         runMiddleware(req, res, options, function(err) {
             should.not.exist(err);
@@ -202,6 +202,22 @@ describe('middleware', function() {
             should.not.exist(err);
             assert(res.headers[HEADER_NAME], 'Expected JWT header to be present');
         });
+    });
+
+    it('should resolve the domain when the port is not included', function() {
+
+        var req = {
+            method: 'POST',
+            get: function() {
+                return 'mysite.com';
+            }
+        };
+        var res = {};
+        var options = {};
+
+        // The assert to check the domain is located in a function on the
+        // object returned by 'getRes()', which is called by 'runMiddleware()'
+        runMiddleware(req, res, options, function() {});
     });
 
     it('should return and validate tokens for GET and POST in AUTHED_TOKEN mode', function() {


### PR DESCRIPTION
# Issue
`resolveDomain()` would return `'.'` when the port was not included:
```javascript
var domain = host.substr(0, host.indexOf(':') || host.length); // Ex: "mysite.com"
```
When `host.indexOf(':') === -1`, then `host.substr(0, -1)`, which is an empty string, is assigned to the variable `domain`. The return value is then `'.' + ''`.

To fix this I added a check to see if `host.indexOf(':') > -1` and if it is then use that, otherwise use `host.length`. Now a host value of `'mysite.com'` will return `'.mysite.com'`. I've also updated the tests to add a test case where a host without a port is used.