### PR TITLE
Updates jsonwebtoken to ^8.3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ var JWT = {
 
         // Then sign it using jsonwebtoken
         return jsonwebtoken.sign(encryptedToken, options.secret, {
-            expiresInMinutes: options.expiresInMinutes || DEFAULT_EXPIRATION_IN_MINUTES
+            expiresIn: options.expiresIn || DEFAULT_EXPIRATION_IN_MINUTES
         });
     },
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "krakenjs"
   ],
   "dependencies": {
-    "jsonwebtoken": "^4.2.2",
+    "jsonwebtoken": "^8.3.0",
     "node-uuid": "^1.4.3",
     "on-headers": "~1.0.0",
     "underscore": "^1.8.3"


### PR DESCRIPTION
Updates jsonwebtoken to ^8.3.0 to patch necessary security issues with 4.2.2.  
Replaces the 'expiresInMinutes' with the new 'expiresIn' function